### PR TITLE
Add CelebA-HQ dataset for benchmarking

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CliMADatasets"
 uuid = "49523d62-8978-4391-abdd-b8467d4505ae"
 authors = ["Climate Modeling Alliance"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 DataDeps = "124859b0-ceae-595e-8997-d05f6a7a8dfe"

--- a/src/CliMADatasets.jl
+++ b/src/CliMADatasets.jl
@@ -5,10 +5,14 @@ using HDF5
 using MLDatasets
 using MLUtils
 
+include("datasets/celeba_hq.jl")
 include("datasets/turbulence_2d.jl")
+
+export CelebAHQ
 export Turbulence2D
 
 function __init__()
+    __init__celeba_hq()
     __init__turbulence_2d()
 end
 

--- a/src/datasets/celeba_hq.jl
+++ b/src/datasets/celeba_hq.jl
@@ -1,0 +1,88 @@
+function __init__celeba_hq()
+    DEPNAME = "CelebAHQ"
+
+    celeba_hq_32x32_train_female = "https://caltech.box.com/shared/static/h94hiq9vm7m1dc1aailaslldjmoitfab.hdf5"
+    celeba_hq_32x32_train_male = "https://caltech.box.com/shared/static/gqzz6yh98wsjbdiv4cf5kmpv3hkf9hlq.hdf5"
+    celeba_hq_32x32_val_male = "https://caltech.box.com/shared/static/44hf2gg87w0in2jufq55s5mk6iokatdy.hdf5"
+    celeba_hq_32x32_val_female = "https://caltech.box.com/shared/static/0azdg1ss4871h8o170h1zx8lnpdtbvua.hdf5"
+
+    celeba_hq_64x64_train_female = "https://caltech.box.com/shared/static/g5yw9byvylb1db8c6bv76fdu9mcnqlcn.hdf5"
+    celeba_hq_64x64_train_male = "https://caltech.box.com/shared/static/wilbz7y64inq1v0pfj0okxjvyctcby5q.hdf5"
+    celeba_hq_64x64_val_male = "https://caltech.box.com/shared/static/kgf4h5h1npa4a5xpc9uc2isoqi1mszkx.hdf5"
+    celeba_hq_64x64_val_female = "https://caltech.box.com/shared/static/6816j46mhhnfl365k0hgbozksbw4y64q.hdf5"
+
+    celeba_hq_128x128_train_female = "https://caltech.box.com/shared/static/1equ12ge7c4qg1u7h4x5fvqaijwxbur1.hdf5"
+    celeba_hq_128x128_train_male = "https://caltech.box.com/shared/static/zmvhpql2uazqlpl31c5kysx4plbbbx91.hdf5"
+    celeba_hq_128x128_val_male = "https://caltech.box.com/shared/static/q6pr6ch603e9p0ugbkkg2gvt7l7ne189.hdf5"
+    celeba_hq_128x128_val_female = "https://caltech.box.com/shared/static/8yqzybwqcgt2s9azxahi4zycvjs1x7jn.hdf5"
+
+    celeba_hq_256x256_train_female = "https://caltech.box.com/shared/static/9oqdtqu0zugbwh78rxgj1wdwnuocxbih.hdf5"
+    celeba_hq_256x256_train_male = "https://caltech.box.com/shared/static/49eskrayxpfm9xcj6nfxakm6iz4sw8y0.hdf5"
+    celeba_hq_256x256_val_male = "https://caltech.box.com/shared/static/wdnwwv75gs7g9b8pj604jyr9vnj76smb.hdf5"
+    celeba_hq_256x256_val_female = "https://caltech.box.com/shared/static/rzadbhcgsp3xh8uhv2s9tf5yj353e6qj.hdf5"
+
+    register(DataDep(
+        DEPNAME,
+        """
+        Dataset: High-quality version of CelebA dataset.
+        Authors: Tero Karras, Timo Aila, Samuli Laine, Jaakko Lehtinen
+        Website: https://github.com/tkarras/progressive_growing_of_gans#preparing-datasets-for-training
+        Disclaimer: CelebAHQ dataset may contain bias. For more information please check Tensorflow.org 
+        [here](https://www.tensorflow.org/responsible_ai/fairness_indicators/tutorials/Fairness_Indicators_TFCO_CelebA_Case_Study).
+
+        References:
+        [Progressive Growing of GANs for Improved Quality, Stability, and Variation](http://arxiv.org/abs/1710.10196)
+        """,
+        [celeba_hq_32x32_train_female, celeba_hq_32x32_train_male, celeba_hq_32x32_val_male, celeba_hq_32x32_val_female, 
+        celeba_hq_64x64_train_female, celeba_hq_64x64_train_male, celeba_hq_64x64_val_male, celeba_hq_64x64_val_female, 
+        celeba_hq_128x128_train_female, celeba_hq_128x128_train_male, celeba_hq_128x128_val_male, celeba_hq_128x128_val_female, 
+        celeba_hq_256x256_train_female, celeba_hq_256x256_train_male, celeba_hq_256x256_val_male, celeba_hq_256x256_val_female],
+    ))
+end
+
+"""
+    CelebAHQ(; split=:train, resolution=32, dir=nothing)
+High-quality version of CelebA dataset.
+Authors: Tero Karras, Timo Aila, Samuli Laine, Jaakko Lehtinen
+Website: https://github.com/tkarras/progressive_growing_of_gans#preparing-datasets-for-training
+"""
+struct CelebAHQ <: MLDatasets.UnsupervisedDataset
+    metadata::Dict{String,Any}
+    split::Symbol
+    resolution::Int
+    gender::Symbol
+    features::Array{}
+end
+
+CelebAHQ(; split=:train, resolution=32, gender=:female, Tx=Float32, dir=nothing) = CelebAHQ(Tx, resolution, split, gender; dir)
+CelebAHQ(split::Symbol; kws...) = CelebAHQ(; split, kws...)
+CelebAHQ(resolution::Symbol; kws...) = CelebAHQ(; resolution, kws...)
+CelebAHQ(Tx::Type; kws...) = CelebAHQ(; Tx, kws...)
+
+function CelebAHQ(Tx::Type, resolution::Int, split::Symbol, gender::Symbol; dir=nothing)
+    DEPNAME = "CelebAHQ"
+
+    @assert split ∈ (:train, :test)
+    @assert gender ∈ (:male, :female)
+
+    if resolution in 2 .^ (5:8)
+        newsplit = split == :test ? :val : split
+        HDF5FILE = "celeba_hq_$(resolution)x_$(resolution)_$(newsplit)_$(gender).hdf5"
+    else
+        error("$resolution x $resolution not supported for CelebA-HQ dataset.")
+    end
+
+    # local path extraction
+    features_path = MLDatasets.datafile(DEPNAME, HDF5FILE, dir)
+
+    # loading
+    fid = h5open(features_path, "r")
+    features = read(fid)["imgs"]
+    close(fid)
+
+    # useful side information
+    metadata = Dict{String,Any}()
+    metadata["n_observations"] = size(features)[end]
+
+    return CelebAHQ(metadata, split, resolution, gender, Tx.(features))
+end

--- a/src/datasets/turbulence_2d.jl
+++ b/src/datasets/turbulence_2d.jl
@@ -1,6 +1,6 @@
 function __init__turbulence_2d()
     DEPNAME = "Turbulence2D"
-
+    
     register(DataDep(
         DEPNAME,
         """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,9 +2,21 @@ using CliMADatasets
 using Test
 
 @testset "CliMADatasets.jl" begin
-    @testset "Turbulence2D" begin
-        n_features = (512, 512)
+    @testset "CelebAHQ" begin
+        for split in (:train, :test)
+            for gender in (:male, :female)
+                for resolution in 2 .^ (5:8)
+                    d = CelebAHQ(split, resolution=resolution, gender=gender)
+                    @test d.split == split
+                    @test d.resolution == resolution
+                    @test d.gender == gender
+                    @test size(d[:])[1:2] == (resolution, resolution)
+                end
+            end
+        end
+    end
 
+    @testset "Turbulence2D" begin
         d = Turbulence2D(:train, resolution=:high)
         @test d.split == :train
         @test d.resolution == :high


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
Adds a version of the CelebA-HQ dataset for testing purposes.

## To-do
Done.

## Content
A new Datadeps.jl registration and struct for loading CelebA-HQ.


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevent documentation.

-->
