### PR TITLE
Allow only a fraction of the dataset to be loaded

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,11 +52,11 @@ using Test
         @test d.features isa Array{Float32}
         @test size(d[:])[1:2] == (512, 512)
 
-        d = Turbulence2DContext(split=:test, resolution=512, wavenumber=:all)
+        d = Turbulence2DContext(split=:test, resolution=512, wavenumber=:all, fraction=0.5)
         @test d.split == :test
         @test size(d.features)[3] == 3
         @test d.features isa Array{Float32}
         @test size(d[:])[1:2] == (512, 512)
-        @test size(d[:])[4] == 2000
+        @test size(d[:])[4] == 1000
     end    
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Add a keyword argument to allow only a fraction of the dataset to be loaded.

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

----
- [x] I have read and checked the items on the review checklist.
