### PR TITLE
Adds new low-res turbulence dataset with varying non-Gaussian tracer

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CliMADatasets"
 uuid = "49523d62-8978-4391-abdd-b8467d4505ae"
 authors = ["Climate Modeling Alliance"]
-version = "0.7.0"
+version = "0.8.0"
 
 [deps]
 DataDeps = "124859b0-ceae-595e-8997-d05f6a7a8dfe"

--- a/src/CliMADatasets.jl
+++ b/src/CliMADatasets.jl
@@ -7,6 +7,7 @@ using MLUtils
 
 include("datasets/celeba_hq.jl")
 include("datasets/turbulence_2d.jl")
+include("datasets/turbulence_2d_low_res.jl")
 include("datasets/turbulence_2d_context.jl")
 include("datasets/correlated_ou_2d.jl")
 include("datasets/correlated_ou_1d.jl")
@@ -14,6 +15,7 @@ include("datasets/giorgini_2d.jl")
 
 export CelebAHQ
 export Turbulence2D
+export Turbulence2DLowRes
 export Turbulence2DContext
 export CorrelatedOU2D
 export CorrelatedOU1D
@@ -22,6 +24,7 @@ export Giorgini2D
 function __init__()
     __init__celeba_hq()
     __init__turbulence_2d()
+    __init__turbulence_2d_low_res()
     __init__turbulence_2d_context()
     __init__correlated_ou_2d()
     __init__correlated_ou_1d()

--- a/src/datasets/turbulence_2d_low_res.jl
+++ b/src/datasets/turbulence_2d_low_res.jl
@@ -9,7 +9,7 @@ function __init__turbulence_2d_low_res()
         Authors: Climate Modeling Alliance
         Website: N/A
         """,
-        "https://caltech.box.com/shared/static/4kn6b5g68chgti5adho05jyan5184opc.hdf5",
+        "https://caltech.box.com/shared/static/2vysrni7qfuk79azvl1d7aybbqgqacfw.hdf5",
     ))
 end
 
@@ -50,7 +50,7 @@ function Turbulence2DLowRes(split::Symbol; f = 1.0, Tx = Float32, resolution = 3
     features_path = MLDatasets.datafile(DEPNAME, HDF5FILE, nothing)
 
     # loading
-    N = resolution
+    n = resolution
     fid = h5open(features_path, "r")
     if nonlinearity == :weak
         τc = 1.0
@@ -90,7 +90,7 @@ function Turbulence2DLowRes(split::Symbol; f = 1.0, Tx = Float32, resolution = 3
     
     n_observations = size(features)[end]
     n_data = Int(round(n_observations*f))
-    features = features[:,:,1:1:n_data]
+    features = features[:,:,:,1:1:n_data]
     
     # splitting
     if split == :train

--- a/src/datasets/turbulence_2d_low_res.jl
+++ b/src/datasets/turbulence_2d_low_res.jl
@@ -1,0 +1,118 @@
+function __init__turbulence_2d_low_res()
+    DEPNAME = "Turbulence2DLowRes"
+    
+    register(DataDep(
+        DEPNAME,
+        """
+        Dataset: Two-dimensional images generated via a forced-dissipative turbulence simulation with
+        passive idealized condensation tracer.
+        Authors: Climate Modeling Alliance
+        Website: N/A
+        """,
+        "https://caltech.box.com/shared/static/4kn6b5g68chgti5adho05jyan5184opc.hdf5",
+    ))
+end
+
+"""
+    Turbulence2DLowRes <: MLDatasets.UnsupervisedDataset
+
+Two-dimensional images generated via a forced-dissipative turbulence simulation with
+passive tracer.
+
+Due to correlations in time, all images are only approximately independent.
+
+Authors: Climate Modeling Alliance
+"""
+struct Turbulence2DLowRes <: MLDatasets.UnsupervisedDataset
+    metadata::Dict{String,Any}
+    split::Symbol
+    resolution::Int
+    features::Array{}
+end
+
+"""
+Creates the Turbulence2DLowRes dataset given
+- split: :train or :test
+- f: fraction of data desired
+- Tx: the float type. The dataset was created using Float32
+- resolution: the resolution of the images in the dataset (only 32 is supported currently.)
+"""
+function Turbulence2DLowRes(split::Symbol; f = 1.0, Tx = Float32, resolution = 32, nonlinearity = :strong)
+    DEPNAME = "Turbulence2DLowRes"
+    HDF5FILE = "two_dimensional_turbulence_with_condensation.hdf5"
+
+    # checks
+    @assert resolution ∈ [32]
+    @assert nonlinearity ∈ [:weak, :medium, :strong]
+    @assert split ∈ [:train, :test]
+
+    # local path extraction
+    features_path = MLDatasets.datafile(DEPNAME, HDF5FILE, nothing)
+
+    # loading
+    N = resolution
+    fid = h5open(features_path, "r")
+    if nonlinearity == :weak
+        τc = 1.0
+        ν, nν = 1e-6, 4
+        μ, nμ = 1e-2, 0
+        ε = 0.1
+        γ₀ = 1.0
+        e = 1.0
+        dt = 0.5e-1
+        dt_save = 10.0
+        τ = 10.0
+        features = read(fid, "$(n)_$(ν)_$(nν)_$(μ)_$(nμ)_$(ε)_$(γ₀)_$(e)_$(τc)_$(dt)_$(dt_save)")
+    elseif nonlinearity == :medium
+        τc = 0.1
+        ν, nν = 1e-6, 4
+        μ, nμ = 1e-2, 0
+        ε = 0.1
+        γ₀ = 1.0
+        e = 1.0
+        dt = 0.5e-1
+        dt_save = 10.0
+        τ = 10.0
+        features = read(fid, "$(n)_$(ν)_$(nν)_$(μ)_$(nμ)_$(ε)_$(γ₀)_$(e)_$(τc)_$(dt)_$(dt_save)")
+    elseif nonlinearity == :strong
+        τc = 0.01
+        ν, nν = 1e-6, 4
+        μ, nμ = 1e-2, 0
+        ε = 0.1
+        γ₀ = 1.0
+        e = 1.0
+        dt = 0.5e-1
+        dt_save = 10.0
+        τ = 10.0
+        features = read(fid, "$(n)_$(ν)_$(nν)_$(μ)_$(nμ)_$(ε)_$(γ₀)_$(e)_$(τc)_$(dt)_$(dt_save)")
+    end
+    close(fid)
+    
+    n_observations = size(features)[end]
+    n_data = Int(round(n_observations*f))
+    features = features[:,:,1:1:n_data]
+    
+    # splitting
+    if split == :train
+        features, _ = MLUtils.splitobs(features, at=0.8)
+    elseif split == :test
+        _, features = MLUtils.splitobs(features, at=0.8)
+    end
+    
+    # useful side information
+    metadata = Dict{String,Any}()
+    metadata["n_data"] = n_data
+    metadata["τc"] = τc
+    metadata["ν"] = ν
+    metadata["nν"] = nν
+    metadata["μ"] = μ
+    metadata["nμ"] = nμ
+    metadata["ε"] = ε
+    metadata["γ₀"] = γ₀
+    metadata["e"] = e
+    metadata["dt"] = dt
+    metadata["dt_save"] = dt_save
+    metadata["τ"] = τ
+
+    return Turbulence2DLowRes(metadata, split, resolution, Tx.(features))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,4 +91,17 @@ using Test
             end
         end
     end
+
+    @testset "Turbulence2DLowRes" begin
+        for res in [32]
+            for nl in [:strong, :medium, :weak]
+                d = Turbulence2DLowRes(:train; f = 0.5, resolution = res, nonlinearity = nl)
+                @test d.split == :train
+                @test d.resolution == res
+                @test size(d[:])[1:2] == (res, res)
+                @test d.features isa Array{Float32}
+                @test size(d.features)[end] == 12000 # 80% training data of 50% of total dataset
+            end
+        end
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -100,7 +100,7 @@ using Test
                 @test d.resolution == res
                 @test size(d[:])[1:2] == (res, res)
                 @test d.features isa Array{Float32}
-                @test size(d.features)[end] == 12000 # 80% training data of 50% of total dataset
+                @test size(d.features)[end] == 12061 # 80% training data of 50% of total dataset
             end
         end
     end


### PR DESCRIPTION
Adds a low resolution turbulence dataset with varying strength on non-Gaussianity for a passive tracer field.
Resolution is 32x32.

- [x] Set up dataset
- [x] Write tests
- [x] Add Box link.